### PR TITLE
Use correct branch name for exercise `branch_bender`

### DIFF
--- a/branch_bender/README.md
+++ b/branch_bender/README.md
@@ -16,7 +16,7 @@ Merge the `feature/dashboard` branch into `main` next.
 
 ### Task 3
 
-Merge the `feature/payment` branch into `main` last.
+Merge the `feature/payments` branch into `main` last.
 
 ## Final state
 


### PR DESCRIPTION
Fixes the instructions for the `branch_bender` exercise