### PR TITLE
hp-stage-modified: Add missing step in setup

### DIFF
--- a/hands_on/stage_modified.py
+++ b/hands_on/stage_modified.py
@@ -31,3 +31,5 @@ def download(verbose: bool):
     with open("fruits.txt", "w") as f:
         f.write("apples\nbananas\ncherries\n")
     run_command(["git", "add", "fruits.txt"], verbose)
+    with open("fruits.txt", "a") as f:
+        f.write("dragon fruits\n")


### PR DESCRIPTION
#47 missed one step in the sandbox setup (the omission was in the issue, which caused the PR to miss it).

What's missing? After staging the `fruits.txt`, the file needs to be modified again so that the same file is staged and modified at the same time.

This is fix-up PR to fix that omission.