### PR TITLE
Implement hands on hp-populate-remote

### DIFF
--- a/exercise_utils/cli.py
+++ b/exercise_utils/cli.py
@@ -104,21 +104,3 @@ def run_command_no_exit(command: List[str], verbose: bool) -> Optional[str]:
         if verbose:
             print(e.stderr)
         return None
-
-
-def run_command_with_code(command: List[str], verbose: bool) -> tuple[Optional[str], int]:
-    """Runs the given command and returns (output, return code)."""
-    try:
-        result = subprocess.run(
-            command,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        if verbose:
-            print(result.stdout)
-        return result.stdout, result.returncode
-    except subprocess.CalledProcessError as e:
-        if verbose:
-            print(e.stderr)
-        return e.stderr, e.returncode


### PR DESCRIPTION
## Exercise Discussion

This PR will close #56. Below is a more detailed description of the changes along with implementation notes:

1. Added an `add_origin` function in `exercise_utils/git.py`. This might be helpful in the future. I noticed that there is already a `remove_remote` implementation, and `add_origin` is intended to be used in a similar way.
2. To help ensure that the remote repository `gitmastery-things` is created successfully across multiple attempts, I added a check to delete any existing remote repository with the same name. Please note that this requires setting up delete access for the GitHub CLI via `gh auth refresh -h github.com -s delete_repo`. I also realised that the GitHub CLI needs to be configured beforehand for this part of the hands-on to work.

**Note:** The download script tested via `test-download.sh` works fine. [Here](https://github.com/oadultradeepfield/gitmastery-things) is the remote repo I managed to create.

## Checklist

- [ ] If you require a new remote repository on the `Git-Mastery` organization, have you [created a request](https://github.com/git-mastery/exercises/issues/new?template=request_exercise_repository.md) for it?
- [ ] Have you written unit tests using [`repo-smith`](https://github.com/git-mastery/repo-smith) to validate the exercise grading scheme?
- [X] Have you tested the download script using `test-download.sh`?
- [X] Have you verified that this exercise does not already exist or is not currently in review?
- [ ] Did you introduce a new grading mechanism that should belong to [`git-autograder`](https://github.com/git-mastery/git-autograder)?
- [ ] Did you introduce a new dependency that should belong to [`app`](https://github.com/git-mastery/app)?
