### PR TITLE
[hp-fetch-merge] Fix mismatch in download and manual setup

### DIFF
--- a/hands_on/fetch_merge.py
+++ b/hands_on/fetch_merge.py
@@ -1,6 +1,7 @@
+from exercise_utils.cli import run_command
 import os
 
-from exercise_utils.git import add_remote, clone_repo_with_git, remove_remote
+from exercise_utils.git import clone_repo_with_git
 
 __requires_git__ = True
 __requires_github__ = False
@@ -11,7 +12,4 @@ def download(verbose: bool):
         "https://github.com/git-mastery/samplerepo-finances.git", verbose
     )
     os.chdir("samplerepo-finances")
-    remove_remote("origin", verbose)
-    add_remote(
-        "origin", "https://github.com/git-mastery/samplerepo-finances-2", verbose
-    )
+    run_command(["git", "remote", "set-url", "origin", "https://github.com/git-mastery/samplerepo-finances-2.git"], verbose)


### PR DESCRIPTION
# Exercise Review

## Exercise Discussion

Fix #176

## Checklist

- [ ] If you require a new remote repository on the `Git-Mastery` organization, have you [created a request](https://github.com/git-mastery/exercises/issues/new?template=request_exercise_repository.md) for it?
- [ ] Have you written unit tests using [`repo-smith`](https://github.com/git-mastery/repo-smith) to validate the exercise grading scheme?
- [X] Have you tested the download script using `test-download.sh`?
- [X] Have you verified that this exercise does not already exist or is not currently in review?
- [ ] Did you introduce a new grading mechanism that should belong to [`git-autograder`](https://github.com/git-mastery/git-autograder)?
- [ ] Did you introduce a new dependency that should belong to [`app`](https://github.com/git-mastery/app)?
