### PR TITLE
Fix contribution message workflow permission issue on PR from fork

### DIFF
--- a/.github/workflows/contribution-message.yml
+++ b/.github/workflows/contribution-message.yml
@@ -11,8 +11,9 @@ jobs:
   post_contribution_message:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository # Checks out to base repository default branch (for pull_request_target trigger)
-        uses: actions/checkout@v6 # DO NOT CHECKOUT TO HEAD UNSAFE (will checkout to head of the fork)
+      # DO NOT CHECKOUT TO HEAD UNSAFE (will checkout to head of the fork for pull_request_target trigger)
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
Problem:
* `pull_request` trigger type is forced for PRs that **come from forks** to only have `read` permission for all scopes regardless of what we set explicitly in the workflow -> results in permission issue in contribution comment

Source: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflows-in-forked-repositories


Proposed solution:
* Use `pull_request_target` with restricted scope for GITHUB_TOKEN
* Checkout to base repository default branch instead of the HEAD of the forked repository for security reasons (ensures we only run safe and trusted code in the main branch)

Source: https://www.linkedin.com/pulse/how-access-secrets-running-tests-forked-pull-requests-kylee-fields-7vcne/

Note: this change will only take effect for PRs that appear AFTER this PR is merged.

Alternative solution:
* more complicated flow where we have a `pull_request` trigger that builds relevant artifacts (if needed), then use `workflow_runs` trigger to comment to github (see more here: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/)