### PR TITLE
[tooling] Remove extra comma in contribution message

### DIFF
--- a/scripts/post-contribution-message.py
+++ b/scripts/post-contribution-message.py
@@ -64,7 +64,7 @@ Edit the `.gitmastery.json` configuration file. You need to set the following va
     "exercises_source": {{
         "username": "{FORK_AUTHOR}",
         "repository": "{FORK_REPO}",
-        "branch": "{FORK_BRANCH}",
+        "branch": "{FORK_BRANCH}"
     }}
 }}
 ```


### PR DESCRIPTION
Currently, there is an extra comma in the `exercise-sources` JSON, which causes an error in JSON parsing if we copy it over.

<img width="838" height="195" alt="image" src="https://github.com/user-attachments/assets/9e6c0895-a0b3-44ec-b691-7781f22d34c0" />

<img width="437" height="143" alt="image" src="https://github.com/user-attachments/assets/de5a878c-d3fc-48bf-9d93-9e9c9d1e1587" />

<img width="753" height="278" alt="image" src="https://github.com/user-attachments/assets/313718bf-06b3-44d2-bbb7-f24621092943" />


Fixed the bug to improve developer experience, so that they can copy it directly without any errrors.
