### PR TITLE
Implement include_remote_repo option

### DIFF
--- a/exercise_utils/test.py
+++ b/exercise_utils/test.py
@@ -183,9 +183,7 @@ class GitAutograderTest:
                 False,
                 existing_path=repo_path.absolute().as_posix(),
             )
-
         self.__rs = self.__rs_context.__enter__()
-
         self.__rs.add_helper(GitMasteryHelper)
 
         if self.include_remote_repo:


### PR DESCRIPTION
Fixes #247

Add support for `include_remote_repo` option to create two repo-smith objects.

Potential future improvement: allow creation of more than two repo-smith objects

Example usage in `test_verify.py`:

```python
REPOSITORY_NAME = "test-remote"

loader = GitAutograderTestLoader(REPOSITORY_NAME, verify)


@contextmanager
def base_setup() -> Iterator[Tuple[GitAutograderTest, RepoSmith, RepoSmith]]:
    with loader.start(include_remote_repo=True) as (test, rs, rs_remote):
        rs.git.commit(message="Initial commit", allow_empty=True)
        rs.helper(GitMasteryHelper).create_start_tag()
        yield test, rs, rs_remote


def test_has_origin():
    """Test that origin remote can be added successfully."""
    with base_setup() as (test, rs, rs_remote):
        # Add remote using RepoSmith
        remote_url = str(rs_remote.repo.git_dir)
        rs.repo.create_remote("origin", remote_url) # can name any remote
        rs.git.push("origin", "main") # will support in repo-smith in separate PR
        
        output = test.run()
        assert_output(output, GitAutograderStatus.SUCCESSFUL, [HAS_ORIGIN_REMOTE])

```