### PR TITLE
update verify logic and test case for merge-undo

### DIFF
--- a/merge_undo/test_verify.py
+++ b/merge_undo/test_verify.py
@@ -104,7 +104,8 @@ def test_main_wrong_commit():
             [MAIN_WRONG_COMMIT, RESET_MESSAGE],
         )
 
-def test_not_main():
+
+def test_main_branch_missing():
     with loader.start() as (test, rs):
         _create_and_commit_file(rs, "rick.txt", "Scientist", "Add Rick")
         _create_and_commit_file(rs, "morty.txt", "Boy", "Add Morty")

--- a/merge_undo/verify.py
+++ b/merge_undo/verify.py
@@ -4,7 +4,9 @@ from git_autograder import (
     GitAutograderStatus,
 )
 
-MAIN_BRANCH_MISSING = "Main branch is missing, you can reset the exercises if needed and try again."
+MAIN_BRANCH_MISSING = (
+    "Main branch is missing, you can reset the exercises if needed and try again."
+)
 MERGES_NOT_UNDONE = "It appears the merge commits are still in the history of the 'main' branch. This shouldn't be the case"
 MAIN_WRONG_COMMIT = "The 'main' branch is not pointing to the correct commit. It should be pointing to the commit made just before the merges."
 RESET_MESSAGE = 'Reset the repository using "gitmastery progress reset" and start again'
@@ -16,7 +18,7 @@ def verify(exercise: GitAutograderExercise) -> GitAutograderOutput:
 
     if not main_branch:
         raise exercise.wrong_answer([MAIN_BRANCH_MISSING, RESET_MESSAGE])
-    
+
     main_history = main_branch.commits
 
     if any(len(c.commit.parents) > 1 for c in main_history):


### PR DESCRIPTION
# Exercise Review

## Exercise Discussion
#269 

Removed the unnecessary check that enforces students to be on `main` branch when running `verify`.
## Checklist

- [ ] If you require a new remote repository on the `Git-Mastery` organization, have you [created a request](https://github.com/git-mastery/exercises/issues/new?template=request_exercise_repository.yaml) for it?
- [ ] Have you written unit tests using [`repo-smith`](https://github.com/git-mastery/repo-smith) to validate the exercise grading scheme?
- [ ] Have you tested your changes using the instructions posted?
- [ ] Have you verified that this exercise does not already exist or is not currently in review?
- [ ] Did you introduce a new grading mechanism that should belong to [`git-autograder`](https://github.com/git-mastery/git-autograder)?
- [ ] Did you introduce a new dependency that should belong to [`app`](https://github.com/git-mastery/app)?
